### PR TITLE
feat: Add batch processor metrics

### DIFF
--- a/pkg/batch/batch.go
+++ b/pkg/batch/batch.go
@@ -191,33 +191,43 @@ func (b *batcher) do(
 			limiter := processor.getLimiterFn(key)
 
 			for !b.deleted && !b.isEmpty() {
-				// Delay start of batch processing based on the max of the initial delay and delay due to throttling.
-				reservation := limiter.Reserve()
-				timeToDelay := maxDuration(delayBeforeStart, reservation.Delay())
-
-				if timeToDelay > 0 {
-					time.Sleep(timeToDelay)
-
-					if timeToDelay == delayBeforeStart {
-						processor.logger.Verbosef("Delayed processing of batch %q by %v due to start delay", key, timeToDelay)
-					} else {
-						processor.logger.Warningf("Delayed processing of batch %q by %v due to client-side throttling", key, timeToDelay)
-					}
-				}
-
-				// Get the next batch of entries to process.
-				entries, deadline := b.flush()
-				if len(entries) <= 0 {
-					break
-				}
-
-				values := make([]interface{}, len(entries))
-				for i, entry := range entries {
-					values[i] = entry.value
-				}
-
-				// Scope the (potential) context cancelation in a function closure.
+				// Scope the loop deferals in a function closure.
 				func() {
+					var (
+						batchSize int
+						err       error
+					)
+
+					batchRecorder := processor.metricsRecorder.RecordBatchStart(key)
+					defer func() { batchRecorder.RecordBatchCompletion(batchSize, err) }()
+
+					// Delay start of batch processing based on the max of the initial delay and delay due to throttling.
+					reservation := limiter.Reserve()
+					timeToDelay := maxDuration(delayBeforeStart, reservation.Delay())
+
+					if timeToDelay > 0 {
+						time.Sleep(timeToDelay)
+
+						if timeToDelay == delayBeforeStart {
+							processor.logger.Verbosef("Delayed processing of batch %q by %v due to start delay", key, timeToDelay)
+						} else {
+							processor.logger.Warningf("Delayed processing of batch %q by %v due to client-side throttling", key, timeToDelay)
+							batchRecorder.RecordRateLimitDelay(timeToDelay)
+						}
+					}
+
+					// Get the next batch of entries to process.
+					entries, deadline := b.flush()
+					batchSize = len(entries)
+					if batchSize <= 0 {
+						return
+					}
+
+					values := make([]interface{}, len(entries))
+					for i, entry := range entries {
+						values[i] = entry.value
+					}
+
 					innerCtx := context.Background()
 					if !deadline.IsZero() {
 						var cancel func()
@@ -225,7 +235,8 @@ func (b *batcher) do(
 						defer cancel()
 					}
 
-					results, err := processor.fn(innerCtx, key, values)
+					var results []interface{}
+					results, err = processor.fn(innerCtx, key, values)
 
 					for i, entry := range entries {
 						var valResult interface{}
@@ -246,8 +257,8 @@ func (b *batcher) do(
 					}
 				}()
 
-				// We only want to delay before the initial start of batch processing assuming the more
-				// request will come in before the configured delay. On subsequent iterations of this loop,
+				// We only want to delay before the initial start of batch processing assuming that more
+				// requests will come in before the configured delay. On subsequent iterations of this loop,
 				// we rely on the latency of the operation to naturally batch new requests.
 				delayBeforeStart = 0
 			}
@@ -320,6 +331,10 @@ func (p *Processor) applyDefaults() {
 	if p.logger == nil {
 		p.logger = NewStandardLogger()
 	}
+
+	if p.metricsRecorder == nil {
+		p.metricsRecorder = &nullRecorder
+	}
 }
 
 // NewProcessor returns a new batch processor.
@@ -377,5 +392,12 @@ func WithBatchLimits(limit rate.Limit, burst int) ProcessorOption {
 func WithLogger(l Logger) ProcessorOption {
 	return func(p *Processor) {
 		p.logger = l
+	}
+}
+
+// WithMetricsRecorder sets the metrics recorder.
+func WithMetricsRecorder(metricsRecorder ProcessorMetricsRecorder) ProcessorOption {
+	return func(p *Processor) {
+		p.metricsRecorder = metricsRecorder
 	}
 }

--- a/pkg/batch/interface.go
+++ b/pkg/batch/interface.go
@@ -16,6 +16,9 @@ limitations under the License.
 
 package batch
 
+import "time"
+
+// Logger defines an interface for logging.
 type Logger interface {
 	// Logs to the verbose log. It handles the arguments in the manner of fmt.Printf.
 	Verbosef(format string, v ...interface{})
@@ -28,4 +31,19 @@ type Logger interface {
 
 	// Logs to the error log. It handles the arguments in the manner of fmt.Printf.
 	Errorf(format string, v ...interface{})
+}
+
+// MetricsRecorder defines an interface for recording batch metrics.
+type MetricsRecorder interface {
+	// Records the rate limit delay, if any, incurred by the current batch.
+	RecordRateLimitDelay(delay time.Duration)
+
+	// Records completion of processing for the current batch.
+	RecordBatchCompletion(size int, err error)
+}
+
+// ProcessorMetricsRecorder defines an interface for recording batch processor metrics.
+type ProcessorMetricsRecorder interface {
+	// Records the processing start for a single batch of values for the specified key.
+	RecordBatchStart(key string) MetricsRecorder
 }

--- a/pkg/batch/metrics.go
+++ b/pkg/batch/metrics.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import "time"
+
+type nullMetricsRecorder struct {
+}
+
+var (
+	nullRecorder                          = nullMetricsRecorder{}
+	_            ProcessorMetricsRecorder = &nullRecorder
+	_            MetricsRecorder          = &nullRecorder
+)
+
+func (n *nullMetricsRecorder) RecordBatchStart(key string) MetricsRecorder {
+	return n
+}
+
+func (n *nullMetricsRecorder) RecordRateLimitDelay(delay time.Duration) {
+
+}
+
+func (n *nullMetricsRecorder) RecordBatchCompletion(size int, err error) {
+
+}

--- a/pkg/batch/types.go
+++ b/pkg/batch/types.go
@@ -59,6 +59,9 @@ type BatchFunc func(ctx context.Context, key string, values []interface{}) ([]in
 // value for any given key.
 type GetLimiterFunc func(key string) *rate.Limiter
 
+// GetProcessorMetricsRecorderFunc returns a metrics recorder a Processor can use to record metrics.
+type GetProcessorMetricsRecorderFunc func() ProcessorMetricsRecorder
+
 // ProcessorOption modifies the Process configuration.
 type ProcessorOption func(p *Processor)
 
@@ -70,6 +73,7 @@ type Processor struct {
 	delayBeforeStart time.Duration
 	getLimiterFn     GetLimiterFunc
 	logger           Logger
+	metricsRecorder  ProcessorMetricsRecorder
 	batches          sync.Map
 	limiters         sync.Map
 }

--- a/pkg/metrics/azure_batch_metrics.go
+++ b/pkg/metrics/azure_batch_metrics.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"sigs.k8s.io/cloud-provider-azure/pkg/batch"
+)
+
+type BatchMetricsRecorder struct {
+	attributes []string
+}
+
+type BatchProcessorMetricsRecorder struct {
+	request string
+	source  string
+}
+
+const keyAttributesSeparator = "|"
+
+var (
+	_ batch.MetricsRecorder          = &BatchMetricsRecorder{}
+	_ batch.ProcessorMetricsRecorder = &BatchProcessorMetricsRecorder{}
+)
+
+// KeyFromAttributes concatenates the parameters to form a unique key for the referenced resource. Since the
+// values are case-insensitive, they are converted to lowercase before concatentation.
+func KeyFromAttributes(subscriptionID, resourceGroup, resourceName string) string {
+	return strings.Join(
+		[]string{
+			strings.ToLower(subscriptionID),
+			strings.ToLower(resourceGroup),
+			strings.ToLower(resourceName)},
+		keyAttributesSeparator,
+	)
+}
+
+// AttributesFromKey extracts the attributes from a unique key created by KeyFromAttributes.
+func AttributesFromKey(key string) (subscriptionID, resourceGroup, resourceName string) {
+	attrs := strings.Split(key, keyAttributesSeparator)
+	if len(attrs) != 3 {
+		panic(fmt.Sprintf("invalid batch key: %q", key))
+	}
+
+	subscriptionID = attrs[0]
+	resourceGroup = attrs[1]
+	resourceName = attrs[2]
+	return
+}
+
+// NewBatchProcessorMetricsRecorder creates a new batch processor metrics recorder.
+func NewBatchProcessorMetricsRecorder(prefix, request, source string) *BatchProcessorMetricsRecorder {
+	return &BatchProcessorMetricsRecorder{
+		request: prefix + "_" + request,
+		source:  source,
+	}
+}
+
+// Records the processing start for a single batch of values for the specified key.
+func (r *BatchProcessorMetricsRecorder) RecordBatchStart(key string) batch.MetricsRecorder {
+	subscriptionID, resourceGroup, _ := AttributesFromKey(key)
+	return &BatchMetricsRecorder{
+		attributes: []string{r.request, resourceGroup, subscriptionID, r.source},
+	}
+}
+
+// Records the rate limit delay, if any, incurred by the current batch.
+func (r *BatchMetricsRecorder) RecordRateLimitDelay(delay time.Duration) {
+	apiMetrics.rateLimitDelay.WithLabelValues(r.attributes...).Observe(delay.Seconds())
+}
+
+// Records completion of processing for the current batch.
+func (r *BatchMetricsRecorder) RecordBatchCompletion(size int, err error) {
+	apiMetrics.batchSize.WithLabelValues(r.attributes...).Observe(float64(size))
+}

--- a/pkg/metrics/azure_metrics.go
+++ b/pkg/metrics/azure_metrics.go
@@ -44,8 +44,10 @@ var (
 type apiCallMetrics struct {
 	latency          *metrics.HistogramVec
 	errors           *metrics.CounterVec
+	rateLimitDelay   *metrics.HistogramVec
 	rateLimitedCount *metrics.CounterVec
 	throttledCount   *metrics.CounterVec
+	batchSize        *metrics.HistogramVec
 }
 
 // operationCallMetrics is the metrics measuring the performance of a whole operation
@@ -126,6 +128,16 @@ func registerAPIMetrics(attributes ...string) *apiCallMetrics {
 			},
 			append(attributes, "code"),
 		),
+		rateLimitDelay: metrics.NewHistogramVec(
+			&metrics.HistogramOpts{
+				Namespace:      consts.AzureMetricsNamespace,
+				Name:           "api_request_ratelimited_delays",
+				Help:           "Client-side throttling delay on Azure API calls",
+				Buckets:        metrics.ExponentialBuckets(0.050, 2, 10),
+				StabilityLevel: metrics.ALPHA,
+			},
+			attributes,
+		),
 		rateLimitedCount: metrics.NewCounterVec(
 			&metrics.CounterOpts{
 				Namespace:      consts.AzureMetricsNamespace,
@@ -144,12 +156,24 @@ func registerAPIMetrics(attributes ...string) *apiCallMetrics {
 			},
 			attributes,
 		),
+		batchSize: metrics.NewHistogramVec(
+			&metrics.HistogramOpts{
+				Namespace:      consts.AzureMetricsNamespace,
+				Name:           "api_request_batch_sizes",
+				Help:           "Batch sizes for batch processing requests.",
+				Buckets:        metrics.ExponentialBuckets(1.0, 2.0, 7),
+				StabilityLevel: metrics.ALPHA,
+			},
+			attributes,
+		),
 	}
 
 	legacyregistry.MustRegister(metrics.latency)
 	legacyregistry.MustRegister(metrics.errors)
+	legacyregistry.MustRegister(metrics.rateLimitDelay)
 	legacyregistry.MustRegister(metrics.rateLimitedCount)
 	legacyregistry.MustRegister(metrics.throttledCount)
+	legacyregistry.MustRegister(metrics.batchSize)
 
 	return metrics
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Adds batch processing metrics.

1. cloudprovider_azure_api_request_batch_sizes: A histogram metric of batch sizes.
2. cloudprovider_azure_api_request_ratelimited_delays: A histogram metric of delays due to client-side throttling incurred during batch processing.

For each metric, the following labels specify whether the metric was recorded for an attach or detach disk operation.
1. source="attach_disk" for batched attach disk operations
2. source="detach_disk" for batched detach disk operations


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
