### PR TITLE
chore: make VmUpdateRequired public

### DIFF
--- a/pkg/provider/azure_controller_common.go
+++ b/pkg/provider/azure_controller_common.go
@@ -356,7 +356,7 @@ func (c *controllerCommon) attachDiskBatchToNode(ctx context.Context, subscripti
 
 		err = vmset.WaitForUpdateResult(resultCtx, future, nodeName, "attach_disk")
 	updateRetryLoop:
-		for c.vmUpdateRequired(future, err) {
+		for vmUpdateRequired(future, err) {
 			select {
 			case <-resultCtx.Done():
 				err = context.DeadlineExceeded
@@ -373,7 +373,7 @@ func (c *controllerCommon) attachDiskBatchToNode(ctx context.Context, subscripti
 		// if no error was returned, attach was successful
 		if err == nil {
 			klog.V(2).Infof("azuredisk - successfully attached disks to node %s: %s", nodeName, diskMap)
-		} else if !errors.Is(err, context.DeadlineExceeded) && configAccepted(future) {
+		} else if !errors.Is(err, context.DeadlineExceeded) && VMConfigAccepted(future) {
 			err = retry.NewPartialUpdateError(err.Error())
 		}
 
@@ -669,9 +669,9 @@ func (c *controllerCommon) checkDiskExists(ctx context.Context, diskURI string) 
 	return true, nil
 }
 
-func (c *controllerCommon) vmUpdateRequired(future *azure.Future, err error) bool {
+func vmUpdateRequired(future *azure.Future, err error) bool {
 	errCode := getErrorCode(err)
-	return configAccepted(future) && errCode != nil && *errCode == consts.OperationPreemptedErrorCode
+	return VMConfigAccepted(future) && errCode != nil && *errCode == consts.OperationPreemptedErrorCode
 }
 
 func getValidCreationData(subscriptionID, resourceGroup, sourceResourceID, sourceType string) (compute.CreationData, error) {
@@ -729,7 +729,7 @@ func getErrorCode(err error) *string {
 	return &matches[1]
 }
 
-func configAccepted(future *azure.Future) bool {
+func VMConfigAccepted(future *azure.Future) bool {
 	// if status code indicates success, the storage profile change was committed
 	return future != nil && future.Response() != nil && future.Response().StatusCode/100 == 2
 }

--- a/pkg/provider/azure_controller_common_test.go
+++ b/pkg/provider/azure_controller_common_test.go
@@ -1035,8 +1035,6 @@ func TestVmUpdateRequired(t *testing.T) {
 
 	rejectedFuture, _ := azure.NewFutureFromResponse(r)
 
-	azCloud := GetTestCloud(ctrl)
-
 	testCases := []struct {
 		desc           string
 		configAccepted bool
@@ -1071,7 +1069,7 @@ func TestVmUpdateRequired(t *testing.T) {
 			} else {
 				future = &rejectedFuture
 			}
-			result := azCloud.vmUpdateRequired(future, test.err)
+			result := vmUpdateRequired(future, test.err)
 			assert.Equalf(t, test.expectedResult, result, "TestCase[%d] returned %v", i, result)
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
* `VmUpdateRequired` needs to be public in order to be able to assess and return `PartialUpdateError` in `azuredisk-driver/cloud-provisioner`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
